### PR TITLE
Restrict pandas version

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -20,5 +20,5 @@ title = ElexonDataPortal
 doc_path = docs
 doc_host = https://OSUKED.github.io
 doc_baseurl = /ElexonDataPortal/
-requirements = pandas>=1.2.0 requests>=2.25.0 tqdm>=4.61.0 xmltodict>=0.12.0
+requirements = pandas>=1.2.0,<2 requests>=2.25.0 tqdm>=4.61.0 xmltodict>=0.12.0
 dev_requirements = fastcore==1.3.19 jinja2>=3.0.0 nbdev==1.1.15 typer>=0.3.2 pyyaml>=5.4.1 geopandas>=0.9.0 moepy>=1.1.4 croniter>=1.0.15 seaborn>=0.11.1


### PR DESCRIPTION
Pandas v2 introduces a timezone comparison error as described in https://github.com/OSUKED/ElexonDataPortal/issues/23

while fixing the underlying issue would be great this should stop the package from appearing broken to new users. 